### PR TITLE
Gcc overview changes

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,16 +1,16 @@
 - [Cloud Management Portal for GCC 2.0](overview)
 - [What's new](whats-new)
-- [GCC 1.0 vs GCC 2.0](gcc-1-0-vs-gcc-2-0/gcc-1-vs-2)
 - [Log in to CMP](log-in-to-cmp)
 - [Create tenant account](create-tenant-account)
 - [Manage additional tenant account users](manage-additional-tenant-account-users)
 - [Create CSP account](create-csp-account)
-- Manage
+- View and manage
   - [CSP account users](manage-csp-account-users)
   - [Root email mailing list](manage-root-email-mailing-list)
   - [Centralised logs and monitoring](gcc-central-logging-system/manage-centralised-logs-and-monitoring)
   - [Tenant billing account](manage-tenant-billing-account)
     - [GCC billing report](billing-report-docs/overview-billing-report)
+- [GCC 1.0 vs GCC 2.0](gcc-1-0-vs-gcc-2-0/gcc-1-vs-2)
 - [Glossary](glossary)
 - [Support](support/support-channels)
 - [Terms and policies](terms-and-policies)

--- a/overview.md
+++ b/overview.md
@@ -31,6 +31,8 @@ Public officers onboarded to GCC 2.0 can request for tenant and cloud accounts u
 >
 >- Alternatively, another public officer can invite you to TechPass and SEED via the [TechBiz portal](portal.techbiz.suite.gov.sg).
 >
+>- If you already have an active TechPass account and only need to onboard your internet device to SEED, request only for SEED provisioning.
+>
 >- If you have issues in signing up for TechPass account or activating your TechPass account, [create a support request](https://go.gov.sg/techpass-sr). For more information, refer to [support](https://docs.developer.tech.gov.sg/docs/gcc-version-2-user-documentation/support/support-channels)page.
 
 2. Your agency must have an [ITSM project](https://docs.developer.tech.gov.sg/docs/gcc-version-2-user-documentation/support/support-channels?id=create-itsm-project). This is required to raise support requests for issues with GCC 2.0 services.


### PR DESCRIPTION
Updated:
TOC (shifted the GCC 1.0 vs GCC 2.0 to the end above Glossary)
Included a note for users needing only SEED provisioning in the overview.